### PR TITLE
Support fc auto zoning. #31805526248368

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -10,7 +10,7 @@ if [ -d "$CINDER_DIR" ]; then
     rm -rf $CINDER_DIR
 fi
 
-git clone $CINDER_REPO_URL
+git clone $CINDER_REPO_URL --depth=1
 
 if [ ! -d "$CINDER_DIR/$INFORTREND_DRIVER_DIR" ]; then
     mkdir $CINDER_DIR/$INFORTREND_DRIVER_DIR

--- a/src/eonstor_ds_cli/common_cli.py
+++ b/src/eonstor_ds_cli/common_cli.py
@@ -28,6 +28,7 @@ from cinder.openstack.common import loopingcall
 from cinder.volume.drivers.infortrend.eonstor_ds_cli import cli_factory as cli
 from cinder.volume.drivers.san import san
 from cinder.volume import volume_types
+from cinder.zonemanager import utils as zm_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -138,6 +139,8 @@ class InfortrendCommon(object):
             LOG.error(msg)
             raise exception.InfortrendDriverException(data=msg)
 
+        self.fc_lookup_service = zm_utils.create_lookup_service()
+
         self._volume_stats = None
         self._model_type = 'R'
         self._base_logical_channel = 16
@@ -231,9 +234,7 @@ class InfortrendCommon(object):
 
         if rc == 20:
             LOG.warning(_LW('The MCS Channel is grouped'))
-            return rc
-
-        if rc != 0:
+        elif rc != 0:
             msg = _('Failed to create map')
             LOG.error(msg)
             raise exception.InfortrendCliException(
@@ -987,6 +988,23 @@ class InfortrendCommon(object):
         else:
             return min_map_chl
 
+    def _get_common_lun_map_id(self, wwpn_channel_info):
+        map_lun = None
+
+        for lun_id in range(self.constants['MAX_LUN_MAP_PER_CHL']):
+            lun_id_exist = False
+            for slot_name in ['slot_a', 'slot_b']:
+                for wwpn in wwpn_channel_info:
+                    channel_id = wwpn_channel_info[wwpn]
+                    if channel_id not in self.map_dict[slot_name]:
+                        continue
+                    elif lun_id not in self.map_dict[slot_name][channel_id]:
+                        lun_id_exist = True
+            if not lun_id_exist:
+                map_lun = str(lun_id)
+                break
+        return map_lun
+
     def _concat_provider_location(self, model_dict):
         return '@'.join([i + '^' + str(model_dict[i]) for i in model_dict])
 
@@ -1357,11 +1375,55 @@ class InfortrendCommon(object):
         self._init_map_info(multipath)
         self._update_map_info(multipath)
 
+        if self.fc_lookup_service is not None:
+            map_lun, target_wwpns, initiator_target_map = (
+                self._do_fc_zoning_connect(volume, connector)
+            )
+        else:
+            map_lun, target_wwpns, initiator_target_map = (
+                self._do_fc_normal_connect(volume, connector, multipath)
+            )
+        properties = self._generate_fc_connection_properties(
+            map_lun, target_wwpns, initiator_target_map)
+
+        LOG.info(_LI('Successfully initialize connection '
+                     'target_wwn: %(target_wwn)s '
+                     'initiator_target_map: %(initiator_target_map)s'
+                     'lun: %(target_lun)s '), properties['data'])
+        return properties
+
+    def _do_fc_zoning_connect(self, volume, connector):
         volume_id = volume['id'].replace('-', '')
         target_wwpns = []
 
         partition_data = self._extract_all_provider_location(
-            volume['provider_location'])  # system_id, part_id
+            volume['provider_location'])
+        part_id = partition_data['partition_id']
+
+        if part_id == 'None':
+            part_id = self._get_part_id(volume_id)
+
+        wwpn_list, wwpn_channel_info = self._get_wwpn_list()
+
+        initiator_target_map, target_wwpns = self._build_initiator_target_map(
+            connector, wwpn_list)
+
+        map_lun = self._get_common_lun_map_id(wwpn_channel_info)
+
+        for initiator_wwpn in initiator_target_map:
+            for target_wwpn in initiator_target_map[initiator_wwpn]:
+                channel_id = wwpn_channel_info[target_wwpn]
+                self._create_map_with_lun_filter(
+                    part_id, channel_id, map_lun, initiator_wwpn)
+
+        return map_lun, target_wwpns, initiator_target_map
+
+    def _do_fc_normal_connect(self, volume, connector, multipath):
+        volume_id = volume['id'].replace('-', '')
+        target_wwpns = []
+
+        partition_data = self._extract_all_provider_location(
+            volume['provider_location'])
         part_id = partition_data['partition_id']
 
         if part_id == 'None':
@@ -1400,17 +1462,10 @@ class InfortrendCommon(object):
 
             target_wwpns.append(wwpn)
 
-        initiator_target_map = self._build_initiator_target_map(
+        initiator_target_map, target_wwpns = self._build_initiator_target_map(
             connector, target_wwpns)
 
-        properties = self._generate_fc_connection_properties(
-            map_lun, target_wwpns, initiator_target_map)
-
-        LOG.info(_LI('Successfully initialize connection '
-                     'target_wwn: %(target_wwn)s '
-                     'initiator_target_map: %(initiator_target_map)s'
-                     'lun: %(target_lun)s '), properties['data'])
-        return properties
+        return map_lun, target_wwpns, initiator_target_map
 
     def _initialize_connection_fc_multipath(
             self, map_chl, map_lun, part_id, wwn_list, connector):
@@ -1436,15 +1491,28 @@ class InfortrendCommon(object):
 
         return wwpn
 
-    def _build_initiator_target_map(self, connector, target_wwpns):
+    def _build_initiator_target_map(self, connector, all_target_wwpns):
         initiator_target_map = {}
+        target_wwpns = []
 
-        initiator_wwns = connector['wwpns']
+        if self.fc_lookup_service is not None:
+            lookup_map = (
+                self.fc_lookup_service.get_device_mapping_from_network(
+                    connector['wwpns'], all_target_wwpns)
+            )
+            for fabric_name in lookup_map:
+                fabric = lookup_map[fabric_name]
+                target_wwpns.extend(fabric['target_port_wwn_list'])
+                for initiator in fabric['initiator_port_wwn_list']:
+                    initiator_target_map[initiator] = \
+                        fabric['target_port_wwn_list']
+        else:
+            initiator_wwns = connector['wwpns']
+            target_wwpns = all_target_wwpns
+            for initiator in initiator_wwns:
+                initiator_target_map[initiator] = all_target_wwpns
 
-        for initiator in initiator_wwns:
-            initiator_target_map[initiator] = target_wwpns
-
-        return initiator_target_map
+        return initiator_target_map, target_wwpns
 
     def _generate_fc_connection_properties(
             self, lun_id, target_wwpns, initiator_target_map):
@@ -1658,6 +1726,18 @@ class InfortrendCommon(object):
             if entry['CH'] == channel_id and entry['ID'] == slot_name:
                 return entry['WWPN']
         return None
+
+    def _get_wwpn_list(self):
+        wwn_list = self._show_wwn()
+
+        wwpn_list = []
+        wwpn_channel_info = {}
+
+        for entry in wwn_list:
+            wwpn_list.append(entry['WWPN'])
+            wwpn_channel_info[entry['WWPN']] = entry['CH']
+
+        return wwpn_list, wwpn_channel_info
 
     @log_func
     def _generate_iscsi_connection_properties(

--- a/src/eonstor_ds_cli/common_cli.py
+++ b/src/eonstor_ds_cli/common_cli.py
@@ -995,7 +995,7 @@ class InfortrendCommon(object):
             lun_id_exist = False
             for slot_name in ['slot_a', 'slot_b']:
                 for wwpn in wwpn_channel_info:
-                    channel_id = wwpn_channel_info[wwpn]
+                    channel_id = wwpn_channel_info[wwpn]['channel']
                     if channel_id not in self.map_dict[slot_name]:
                         continue
                     elif lun_id not in self.map_dict[slot_name][channel_id]:
@@ -1412,9 +1412,11 @@ class InfortrendCommon(object):
 
         for initiator_wwpn in initiator_target_map:
             for target_wwpn in initiator_target_map[initiator_wwpn]:
-                channel_id = wwpn_channel_info[target_wwpn]
+                channel_id = wwpn_channel_info[target_wwpn]['channel']
+                controller = wwpn_channel_info[target_wwpn]['slot']
                 self._create_map_with_lun_filter(
-                    part_id, channel_id, map_lun, initiator_wwpn)
+                    part_id, channel_id, map_lun, initiator_wwpn,
+                    controller=controller)
 
         return map_lun, target_wwpns, initiator_target_map
 
@@ -1735,7 +1737,15 @@ class InfortrendCommon(object):
 
         for entry in wwn_list:
             wwpn_list.append(entry['WWPN'])
-            wwpn_channel_info[entry['WWPN']] = entry['CH']
+
+            if 'BID:113' == entry['ID']:
+                slot_name = 'slot_b'
+            else:
+                slot_name = 'slot_a'
+            wwpn_channel_info[entry['WWPN']] = {
+                'channel': entry['CH'],
+                'slot': slot_name
+            }
 
         return wwpn_list, wwpn_channel_info
 

--- a/src/infortrend_fc_cli.py
+++ b/src/infortrend_fc_cli.py
@@ -22,6 +22,7 @@ from oslo_log import log as logging
 from cinder.i18n import _LI
 from cinder.volume import driver
 from cinder.volume.drivers.infortrend.eonstor_ds_cli import common_cli
+from cinder.zonemanager import utils as zm_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -133,6 +134,7 @@ class InfortrendCLIFCDriver(driver.FibreChannelDriver):
         """Removes an export for a volume."""
         pass
 
+    @zm_utils.AddFCZone
     def initialize_connection(self, volume, connector):
         """Initializes the connection and returns connection info.
 
@@ -158,6 +160,7 @@ class InfortrendCLIFCDriver(driver.FibreChannelDriver):
                 'initiator': connector['initiator']})
         return self.common.initialize_connection(volume, connector)
 
+    @zm_utils.RemoveFCZone
     def terminate_connection(self, volume, connector, **kwargs):
         """Disallow connection from connector"""
         LOG.info(_LI('terminate_connection volume id=%s') % (

--- a/test/test_infortrend_cli.py
+++ b/test/test_infortrend_cli.py
@@ -263,6 +263,22 @@ class InfortrendCLITestData(object):
         }
     }
 
+    test_initiator_target_map_zoning_r_model = {
+        fake_initiator_wwpns[0]: fake_target_wwpns[1:3],
+        fake_initiator_wwpns[1]: fake_target_wwpns[1:3]
+    }
+
+    test_fc_properties_zoning_r_model = {
+        'driver_volume_type': 'fibre_channel',
+        'data': {
+            'target_discovered': True,
+            'target_lun': fake_lun_map[0],
+            'target_wwn': fake_target_wwpns[1:3],
+            'access_mode': 'rw',
+            'initiator_target_map': test_initiator_target_map_zoning_r_model
+        }
+    }
+
     test_connector = {
         'ip': fake_host_ip[0],
         'initiator': fake_initiator_iqn[0],
@@ -361,26 +377,11 @@ class InfortrendCLITestData(object):
         }
     }
 
-    test_new_type_tp0 = {
-        'id': '0'
-    }
-
-    test_old_volume_tp1 = {
-        'volume_type_id': '1',
-        'id': fake_volume_id[0]
-    }
-
-    test_new_type_4tiers = {
-        'id': '4'
-    }
-
-    test_old_volume_2tiers = {
-        'volume_type_id': '2',
-        'id': fake_volume_id[0]
-    }
-
-    test_new_type = {
-        'id': None
+    fake_lookup_map_r_model = {
+        '12345678': {
+            'initiator_port_wwn_list': fake_initiator_wwpns[:],
+            'target_port_wwn_list': fake_target_wwpns[1:3]
+        }
     }
 
     def get_fake_cli_failed(self):
@@ -1128,41 +1129,6 @@ Return: 0x0000
 """
         return msg % self.fake_lv_id[0]
 
-    def get_test_show_lv_tier_for_tiering(self):
-        return (0, [{
-            'LV-Name': 'LV-1',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '0',
-            'Size': '418.93 GB',
-            'Used': '10 GB(2.4%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '10.0%',
-        }, {
-            'LV-Name': 'LV-1',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '1',
-            'Size': '931.02 GB',
-            'Used': '0 MB(0.0%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '0.0%',
-        }, {
-            'LV-Name': 'LV-1',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '2',
-            'Size': '418.93 GB',
-            'Used': '10 GB(2.4%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '10.0%',
-        }, {
-            'LV-Name': 'LV-1',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '3',
-            'Size': '931.02 GB',
-            'Used': '0 MB(0.0%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '0.0%',
-        }])
-
     def get_test_show_lv_tier_for_migration(self):
         return (0, [{
             'LV-Name': 'TierLV',
@@ -1175,41 +1141,6 @@ Return: 0x0000
         }, {
             'LV-Name': 'TierLV',
             'LV-ID': self.fake_lv_id[1],
-            'Tier': '3',
-            'Size': '931.02 GB',
-            'Used': '0 MB(0.0%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '0.0%',
-        }])
-
-    def get_test_show_lv_4tiers(self):
-        return (0, [{
-            'LV-Name': 'TierLV',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '0',
-            'Size': '418.93 GB',
-            'Used': '10 GB(2.4%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '10.0%',
-        }, {
-            'LV-Name': 'TierLV',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '1',
-            'Size': '931.02 GB',
-            'Used': '0 MB(0.0%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '0.0%',
-        }, {
-            'LV-Name': 'TierLV',
-            'LV-ID': self.fake_lv_id[0],
-            'Tier': '2',
-            'Size': '931.02 GB',
-            'Used': '0 MB(0.0%)',
-            'Data Service': '0 MB(0.0%)',
-            'Reserved Ratio': '0.0%',
-        }, {
-            'LV-Name': 'TierLV',
-            'LV-ID': self.fake_lv_id[0],
             'Tier': '3',
             'Size': '931.02 GB',
             'Used': '0 MB(0.0%)',
@@ -1615,42 +1546,6 @@ Return: 0x0000
                       self.fake_partition_id[0],
                       self.fake_partition_id[0])
 
-    def get_test_show_license_for_retype(self):
-        return (0, {
-            'Storage Tiering': {
-                'Support': True,
-                'Amount': '4'
-            },
-            'Thin Provisioning': {
-                'Support': True,
-                'Amount': '---'
-            }
-        })
-
-    def get_test_show_license_for_retype_without_thin_provisioning(self):
-        return (0, {
-            'Storage Tiering': {
-                'Support': True,
-                'Amount': '4'
-            },
-            'Thin Provisioning': {
-                'Support': False,
-                'Amount': '---'
-            }
-        })
-
-    def get_test_show_license_for_retype_without_tiering(self):
-        return (0, {
-            'Storage Tiering': {
-                'Support': False,
-                'Amount': '2'
-            },
-            'Thin Provisioning': {
-                'Support': True,
-                'Amount': '---'
-            }
-        })
-
     def get_test_show_license(self):
         return (0, {
             'Local Volume Copy': {
@@ -1838,41 +1733,6 @@ Return: 0x0000
             result.append(template % (
                 target_portals[i], target_iqns[i]))
         return (0, '\n'.join(result))
-
-    def get_fake_thin_provisioning_no_support(self):
-        return ({
-            'infortrend_provisioning': 'full'})
-
-    def get_fake_thin_provisioning_support(self):
-        return ({
-            'infortrend_provisioning': 'thin'})
-
-    def get_fake_2tiers_support(self):
-        return ({
-            'infortrend_tiering': '2'})
-
-    def get_fake_4tiers_support(self):
-        return ({
-            'infortrend_tiering': '4'})
-
-    def get_test_show_partition_for_thin_provisioning(
-            self, volume_id=None, pool_id=None):
-        result = [{
-            'ID': self.fake_partition_id[0],
-            'Used': '200',
-            'Name': self.fake_volume_id[0].replace('-', ''),
-            'Size': '1000',
-            'Min-reserve': '200',
-            'LV-ID': self.fake_lv_id[0]
-        }, {
-            'ID': self.fake_partition_id[1],
-            'Used': '200',
-            'Name': self.fake_volume_id[1].replace('-', ''),
-            'Size': '2000',
-            'Min-reserve': '200',
-            'LV-ID': self.fake_lv_id[0]
-        }]
-        return (0, result)
 
 
 class InfortrendCLITestCase(test.TestCase):

--- a/test/test_infortrend_cli.py
+++ b/test/test_infortrend_cli.py
@@ -247,6 +247,22 @@ class InfortrendCLITestData(object):
         }
     }
 
+    test_initiator_target_map_zoning = {
+        fake_initiator_wwpns[0]: fake_target_wwpns[0:2],
+        fake_initiator_wwpns[1]: fake_target_wwpns[0:2]
+    }
+
+    test_fc_properties_zoning = {
+        'driver_volume_type': 'fibre_channel',
+        'data': {
+            'target_discovered': True,
+            'target_lun': fake_lun_map[0],
+            'target_wwn': fake_target_wwpns[0:2],
+            'access_mode': 'rw',
+            'initiator_target_map': test_initiator_target_map_zoning
+        }
+    }
+
     test_connector = {
         'ip': fake_host_ip[0],
         'initiator': fake_initiator_iqn[0],
@@ -337,6 +353,13 @@ class InfortrendCLITestData(object):
     }
 
     fake_volume_id = [test_volume['id'], test_dst_volume['id']]
+
+    fake_lookup_map = {
+        '12345678': {
+            'initiator_port_wwn_list': fake_initiator_wwpns[:],
+            'target_port_wwn_list': fake_target_wwpns[0:2]
+        }
+    }
 
     test_new_type_tp0 = {
         'id': '0'

--- a/test/test_infortrend_common.py
+++ b/test/test_infortrend_common.py
@@ -217,16 +217,14 @@ class InfortrendFCCommonTestCase(InfortrendTestCass):
         test_connector = self.cli_data.test_connector
         test_initiator_wwpns = test_connector['wwpns']
         test_partition_id = self.cli_data.fake_partition_id[0]
-        test_all_target_wwpns = self.cli_data.fake_target_wwpns[:]
-        test_all_target_wwpns[1] = self.cli_data.fake_target_wwpns[2]
-        test_all_target_wwpns[2] = self.cli_data.fake_target_wwpns[1]
+        test_all_target_wwpns = self.cli_data.fake_target_wwpns[0:2]
         test_lookup_map = self.cli_data.fake_lookup_map
 
         mock_commands = {
-            'ShowChannel': self.cli_data.get_test_show_channel_r_model(),
+            'ShowChannel': self.cli_data.get_test_show_channel(),
             'ShowMap': self.cli_data.get_test_show_map(),
             'CreateMap': SUCCEED,
-            'ShowWWN': self.cli_data.get_test_show_wwn()
+            'ShowWWN': self.cli_data.get_test_show_wwn_with_g_model()
         }
         self._driver_setup(mock_commands)
         self.driver.fc_lookup_service = mock.Mock()

--- a/test/test_infortrend_common.py
+++ b/test/test_infortrend_common.py
@@ -234,6 +234,54 @@ class InfortrendFCCommonTestCase(InfortrendTestCass):
             test_connector)
         self.assertTrue(re.match(r'.*Failed to get wwn info.*', ex.msg))
 
+    @mock.patch.object(LOG, 'info', mock.Mock())
+    def test_initialize_connection_with_zoning(self):
+
+        test_volume = self.cli_data.test_volume
+        test_connector = self.cli_data.test_connector
+        test_initiator_wwpns = test_connector['wwpns']
+        test_partition_id = self.cli_data.fake_partition_id[0]
+        test_all_target_wwpns = self.cli_data.fake_target_wwpns[:]
+        test_all_target_wwpns[1] = self.cli_data.fake_target_wwpns[2]
+        test_all_target_wwpns[2] = self.cli_data.fake_target_wwpns[1]
+        test_lookup_map = self.cli_data.fake_lookup_map
+
+        mock_commands = {
+            'ShowChannel': self.cli_data.get_test_show_channel_r_model(),
+            'ShowMap': self.cli_data.get_test_show_map(),
+            'CreateMap': SUCCEED,
+            'ShowWWN': self.cli_data.get_test_show_wwn()
+        }
+        self._driver_setup(mock_commands)
+        self.driver.fc_lookup_service = mock.Mock()
+        get_device_mapping_from_network = \
+            self.driver.fc_lookup_service.get_device_mapping_from_network
+        get_device_mapping_from_network.return_value = test_lookup_map
+
+        properties = self.driver.initialize_connection(
+            test_volume, test_connector)
+
+        get_device_mapping_from_network.assert_has_calls(
+            [mock.call(test_connector['wwpns'], test_all_target_wwpns)])
+
+        expect_cli_cmd = [
+            mock.call('ShowChannel'),
+            mock.call('ShowMap'),
+            mock.call('ShowWWN'),
+            mock.call('CreateMap', 'part', test_partition_id, '0', '112', '0',
+                      'wwn=%s' % test_initiator_wwpns[0]),
+            mock.call('CreateMap', 'part', test_partition_id, '5', '112', '0',
+                      'wwn=%s' % test_initiator_wwpns[0]),
+            mock.call('CreateMap', 'part', test_partition_id, '0', '112', '0',
+                      'wwn=%s' % test_initiator_wwpns[1]),
+            mock.call('CreateMap', 'part', test_partition_id, '5', '112', '0',
+                      'wwn=%s' % test_initiator_wwpns[1])
+        ]
+        self._assert_cli_has_calls(expect_cli_cmd)
+
+        self.assertDictMatch(
+            properties, self.cli_data.test_fc_properties_zoning)
+
 
 class InfortrendiSCSICommonTestCase(InfortrendTestCass):
 


### PR DESCRIPTION
- Use zonemanager to get zoning information and new mapping function.
- The infortrend_slots_a_channels_id, infortrend_slots_b_channels_id, infortrend_fc_multipath is not working with AutoZoning.
- Set zoning_mode = 'fabric' to enable.