### PR TITLE
Add new key infortrend_cli_timeout for CLI copy operations. 

### DIFF
--- a/src/eonstor_ds_cli/common_cli.py
+++ b/src/eonstor_ds_cli/common_cli.py
@@ -46,6 +46,12 @@ infortrend_esds_opts = [
     cfg.IntOpt('infortrend_cli_max_retries',
                default=5,
                help='Maximum retry time for cli. Default is 5'),
+    cfg.IntOpt('infortrend_cli_timeout',
+               default=30,
+               help='Default timeout for CLI copy operations in minutes. '
+               'Support: migrate volume, create cloned volume and '
+               'create volume from snapshot. '
+               'By Default, it is 30 minutes.'),
     cfg.StrOpt('infortrend_slots_a_channels_id',
                default='0,1,2,3,4,5,6,7',
                help='Infortrend raid channel ID list on Slot A '
@@ -126,6 +132,7 @@ class InfortrendCommon(object):
         self.password = self.configuration.san_password
         self.ip = self.configuration.san_ip
         self.cli_retry_time = self.configuration.infortrend_cli_max_retries
+        self.cli_timeout = self.configuration.infortrend_cli_timeout * 60
         self.iqn = "iqn.2002-10.com.infortrend:raid.uid%s.%s%s%s"
 
         if self.ip == '':
@@ -137,7 +144,7 @@ class InfortrendCommon(object):
 
         self._volume_stats = None
         self._model_type = 'R'
-        self._replica_timeout = 30 * 60  # 30 min
+        self._replica_timeout = self.cli_timeout
 
         self.map_dict = {
             'slot_a': {},

--- a/test/test_infortrend_cli.py
+++ b/test/test_infortrend_cli.py
@@ -738,7 +738,7 @@ Return: 0x0000
                       self.fake_lv_id[0])
 
     def get_test_show_replica_detail_for_migrate(
-            self, src_part_id, dst_part_id, volume_id):
+            self, src_part_id, dst_part_id, volume_id, status='Completed'):
         result = [{
             'Pair-ID': self.fake_pair_id[0],
             'Name': 'Cinder-Snapshot',
@@ -761,7 +761,7 @@ Return: 0x0000
             'Timeout': '---',
             'Incremental': '---',
             'Compression': '---',
-            'Status': 'Completed',
+            'Status': status,
             'Progress': '---',
             'Created-time': '01/11/2020 22:20 PM',
             'Sync-commence-time': '01/11/2020 22:20 PM',


### PR DESCRIPTION
Default is 30 minutes.

cc @et10man 