### PR TITLE
Enhance update migrated volume 1

### DIFF
--- a/src/eonstor_ds_cli/common_cli.py
+++ b/src/eonstor_ds_cli/common_cli.py
@@ -1818,12 +1818,8 @@ class InfortrendCommon(object):
         return new_extraspec != old_extraspec
 
     def update_migrated_volume(self, ctxt, volume, new_volume):
-        """Return model update for migrated volume.
-        :param volume: The original volume that was migrated to this backend
-        :param new_volume: The migration volume object that was created on
-                           this backend as part of the migration process
-        :return model_update to update DB with any needed changes
-        """
+        """Return model update for migrated volume."""
+
         src_volume_id = volume['id'].replace('-', '')
         dst_volume_id = new_volume['id'].replace('-', '')
         part_id = self._extract_specific_provider_location(

--- a/src/eonstor_ds_cli/common_cli.py
+++ b/src/eonstor_ds_cli/common_cli.py
@@ -1824,32 +1824,26 @@ class InfortrendCommon(object):
                            this backend as part of the migration process
         :return model_update to update DB with any needed changes
         """
-        src_volume_id = volume.get('id')
-        dst_volume_id = new_volume.get('id')
-        dst_volume_existence = False
-        LOG.debug('Update migrated volume: %(dst)s to %(src)s',
-                  {'dst': dst_volume_id,
-                   'src': src_volume_id})
-        if src_volume_id:
-            src_volume_id = src_volume_id.replace('-', '')
-            dst_volume_id = dst_volume_id.replace('-', '')
-            rc, part_list = self._show_part()
-            for entry in part_list:
-                if entry['Name'] == dst_volume_id:
-                    dst_volume_existence = True
-            if dst_volume_existence:
-                part_id = self._get_part_id(dst_volume_id)
-                self._set_part(part_id, 'name=%s' % src_volume_id)
-                system_id = self._get_system_id(self.ip)
-                model_dict = {
-                    'system_id': system_id,
-                    'partition_id': part_id
-                }
-                model_update = {
-                    "provider_location":
-                        self._concat_provider_location(model_dict)
-                }
-                return model_update
-        LOG.error(_LE('Unable to rename the partition for volume: %s'),
-                  src_volume_id)
-        return None
+        src_volume_id = volume['id'].replace('-', '')
+        dst_volume_id = new_volume['id'].replace('-', '')
+        part_id = self._extract_specific_provider_location(
+            new_volume['provider_location'], 'partition_id')
+
+        if part_id is None:
+            part_id = self._get_part_id(dst_volume_id)
+
+        LOG.debug(
+            'Rename partition %(part_id)s '
+            'into new volume %(new_volume)s', {
+                'part_id': part_id, 'new_volume': dst_volume_id})
+
+        self._set_part(part_id, 'name=%s' % src_volume_id)
+
+        LOG.info(_LI('Update migrated volume %(new_volume)s done'), {
+            'new_volume': new_volume['id']})
+
+        model_update = {
+            'provider_location': new_volume['provider_location']
+        }
+
+        return model_update

--- a/src/infortrend_fc_cli.py
+++ b/src/infortrend_fc_cli.py
@@ -226,3 +226,17 @@ class InfortrendCLIFCDriver(driver.FibreChannelDriver):
             'retype volume id=%(volume_id)s new_type id=%(type_id)s'), {
                 'volume_id': volume['id'], 'type_id': new_type['id']})
         return self.common.retype(ctxt, volume, new_type, diff, host)
+
+    def update_migrated_volume(self, ctxt, volume, new_volume):
+        """Return model update for migrated volume.
+
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :return model_update to update DB with any needed changes
+        """
+        LOG.debug(
+            'update migrated volume original volume id= %(volume_id)s '
+            'new volume id=%(new_volume_id)s', {
+                'volume_id': volume['id'], 'new_volume_id': new_volume['id']})
+        return self.common.update_migrated_volume(ctxt, volume, new_volume)

--- a/src/infortrend_iscsi_cli.py
+++ b/src/infortrend_iscsi_cli.py
@@ -222,3 +222,17 @@ class InfortrendCLIISCSIDriver(driver.ISCSIDriver):
             'retype volume id=%(volume_id)s new_type id=%(type_id)s'), {
                 'volume_id': volume['id'], 'type_id': new_type['id']})
         return self.common.retype(ctxt, volume, new_type, diff, host)
+
+    def update_migrated_volume(self, ctxt, volume, new_volume):
+        """Return model update for migrated volume.
+
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :return model_update to update DB with any needed changes
+        """
+        LOG.debug(
+            'update migrated volume original volume id= %(volume_id)s '
+            'new volume id=%(new_volume_id)s', {
+                'volume_id': volume['id'], 'new_volume_id': new_volume['id']})
+        return self.common.update_migrated_volume(ctxt, volume, new_volume)

--- a/test/test_infortrend_common.py
+++ b/test/test_infortrend_common.py
@@ -1543,27 +1543,25 @@ class InfortrendiSCSICommonTestCase(InfortrendTestCass):
 
     def test_update_migrated_volume(self):
         src_volume = self.cli_data.test_volume
-        dst_volume = self.cli_data.test_dst_volume
+        dst_volume = copy.deepcopy(self.cli_data.test_dst_volume)
+        test_dst_part_id = self.cli_data.fake_partition_id[1]
         test_model_update = {
             'provider_location': 'system_id^%s@partition_id^%s' % (
                 int(self.cli_data.fake_system_id[0], 16),
-                self.cli_data.fake_partition_id[1])
+                test_dst_part_id),
         }
+        dst_volume['provider_location'] = test_model_update
 
         mock_commands = {
-            'ShowPartition': self.cli_data.get_test_show_partition(),
-            'ShowDevice': self.cli_data.get_test_show_device(),
             'SetPartition': SUCCEED
         }
         self._driver_setup(mock_commands)
 
-        model_update = self.driver.update_migrated_volume(None,
-                                                          src_volume,
-                                                          dst_volume)
+        model_update = self.driver.update_migrated_volume(
+            None, src_volume, dst_volume)
 
         expect_cli_cmd = [
-            mock.call('ShowPartition'),
-            mock.call('SetPartition', self.cli_data.fake_partition_id[1],
+            mock.call('SetPartition', test_dst_part_id,
                       'name=%s' % src_volume['id'].replace('-', ''))
         ]
         self._assert_cli_has_calls(expect_cli_cmd)
@@ -1574,8 +1572,6 @@ class InfortrendiSCSICommonTestCase(InfortrendTestCass):
         dst_volume = self.cli_data.test_dst_volume
 
         mock_commands = {
-            'ShowPartition': self.cli_data.get_test_show_partition(),
-            'ShowDevice': self.cli_data.get_test_show_device(),
             'SetPartition': FAKE_ERROR_RETURN
         }
         self._driver_setup(mock_commands)
@@ -1586,38 +1582,3 @@ class InfortrendiSCSICommonTestCase(InfortrendTestCass):
             None,
             src_volume,
             dst_volume)
-
-        expect_cli_cmd = [
-            mock.call('ShowPartition'),
-            mock.call('SetPartition', self.cli_data.fake_partition_id[1],
-                      'name=%s' % src_volume['id'].replace('-', ''))
-        ]
-        self._assert_cli_has_calls(expect_cli_cmd)
-
-    def test_update_migrated_volume_no_src_volume_id(self):
-        src_volume = {'id': None}
-        dst_volume = self.cli_data.test_dst_volume
-        mock_commands = {
-            'ShowPartition': self.cli_data.get_test_show_partition(),
-            'ShowDevice': self.cli_data.get_test_show_device(),
-            'SetPartition': FAKE_ERROR_RETURN
-        }
-        self._driver_setup(mock_commands)
-        rt = self.driver.update_migrated_volume(None,
-                                                src_volume,
-                                                dst_volume)
-        self.assertEqual(None, rt)
-
-    def test_update_migrated_volume_no_dst_volume_id(self):
-        src_volume = self.cli_data.test_volume
-        dst_volume = {'id': "123-456"}
-        mock_commands = {
-            'ShowPartition': self.cli_data.get_test_show_partition(),
-            'ShowDevice': self.cli_data.get_test_show_device(),
-            'SetPartition': FAKE_ERROR_RETURN
-        }
-        self._driver_setup(mock_commands)
-        rt = self.driver.update_migrated_volume(None,
-                                                src_volume,
-                                                dst_volume)
-        self.assertEqual(None, rt)

--- a/test/test_infortrend_common.py
+++ b/test/test_infortrend_common.py
@@ -1545,12 +1545,11 @@ class InfortrendiSCSICommonTestCase(InfortrendTestCass):
         src_volume = self.cli_data.test_volume
         dst_volume = copy.deepcopy(self.cli_data.test_dst_volume)
         test_dst_part_id = self.cli_data.fake_partition_id[1]
+        dst_volume['provider_location'] = 'system_id^%s@partition_id^%s' % (
+            int(self.cli_data.fake_system_id[0], 16), test_dst_part_id)
         test_model_update = {
-            'provider_location': 'system_id^%s@partition_id^%s' % (
-                int(self.cli_data.fake_system_id[0], 16),
-                test_dst_part_id),
+            'provider_location': dst_volume['provider_location'],
         }
-        dst_volume['provider_location'] = test_model_update
 
         mock_commands = {
             'SetPartition': SUCCEED
@@ -1570,6 +1569,9 @@ class InfortrendiSCSICommonTestCase(InfortrendTestCass):
     def test_update_migrated_volume_rename_fail(self):
         src_volume = self.cli_data.test_volume
         dst_volume = self.cli_data.test_dst_volume
+        test_dst_part_id = self.cli_data.fake_partition_id[1]
+        dst_volume['provider_location'] = 'system_id^%s@partition_id^%s' % (
+            int(self.cli_data.fake_system_id[0], 16), test_dst_part_id)
 
         mock_commands = {
             'SetPartition': FAKE_ERROR_RETURN


### PR DESCRIPTION
- Use provider location to get partition id and set original volume id.
- Add common api into fc and iscsi driver.

I think the following test is not necessary
- test_update_migrated_volume_no_src_volume_id
- test_update_migrated_volume_no_dst_volume_id

cc @et10man 